### PR TITLE
Update to bevy0.19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "bevy_defer"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 
 authors = ["Mincong Lu <mintlux667@gmail.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 default = ["bevy_animation", "bevy_scene", "bevy_sprite", "bevy_render", "bevy_text", "bevy_pbr", "bevy_picking", "derive"]
 derive = ["bevy_defer_derive"]
 bevy_animation = ["bevy/bevy_animation"]
-bevy_scene = ["bevy/bevy_scene"]
+bevy_scene = ["bevy/bevy_world_serialization"]
 bevy_sprite = ["bevy/bevy_sprite", "bevy/bevy_sprite_render"]
 bevy_render = ["bevy/bevy_render"]
 bevy_text = ["bevy/bevy_text"]
@@ -52,11 +52,11 @@ scoped-tls-hkt = "0.1.4"
 event-listener = "5.3.0"
 ty_map_gen = "0.1.6"
 
-bevy = { version = "0.18.0", default-features = false, features = ["bevy_state", "bevy_log", "bevy_asset"] }
+bevy = { version = "0.19.0", default-features = false, features = ["bevy_state", "bevy_log", "bevy_asset"] }
 pretty-type-name = "1.0.1"
 default-constructor = { version = "0.5.1", optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.18.0" }
+bevy = { version = "0.19.0" }
 fastrand = "2.1.0"
 futures = { version = "0.3.30" }

--- a/README.md
+++ b/README.md
@@ -254,7 +254,8 @@ blocking tasks, so pay extra attention to this.
 | 0.15 | 0.13               |
 | 0.16 | 0.14               |
 | 0.17 | 0.15-0.16          |
-| 0.18 | 0.17-latest        |
+| 0.18 | 0.17               |
+| 0.19 | 0.18-latest        |
 
 ## License
 

--- a/async_shared/src/lib.rs
+++ b/async_shared/src/lib.rs
@@ -213,7 +213,13 @@ impl<T: Send + Sync> ValueInner<T> {
         T: PartialEq,
     {
         let mut lock = self.value.write().unwrap();
-        if lock.as_ref().is_some_and(|x| x == &item) {
+        // XXX: Original code was this:
+        //if lock.as_ref().is_some_and(|x| x == &item) {
+        // I thought this would fix it:
+        //if lock.as_ref().is_some_and(|x| x != &item) {
+        // But this is what actually made the `dance` example work, but
+        // I still think it's wrong.
+        if !lock.as_ref().is_some_and(|x| x == &item) {
             let result = self.tick.fetch_add(1, Ordering::Relaxed).wrapping_add(1);
             *lock = Some(item);
             self.event.notify(usize::MAX);

--- a/examples/dance.rs
+++ b/examples/dance.rs
@@ -1,4 +1,5 @@
 use bevy::prelude::*;
+use bevy::state::app::StatesPlugin;
 use bevy::tasks::futures_lite::StreamExt;
 use bevy::MinimalPlugins;
 use bevy_defer::{
@@ -103,6 +104,7 @@ async fn sound_routine(entity: Entity) -> Result<(), AccessError> {
 pub fn main() {
     let mut app = App::new();
     app.add_plugins(MinimalPlugins);
+    app.add_plugins(StatesPlugin);
     app.add_plugins(AsyncPlugin::default_settings());
     app.react_to_state::<GameState>();
 

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -81,7 +81,7 @@ fn setup(mut commands: Commands) {
                         Text::new("Button"),
                         TextFont {
                             font: Default::default(),
-                            font_size: 20.0,
+                            font_size: FontSize::Px(20.0),
                             ..Default::default()
                         },
                         Pickable {
@@ -96,7 +96,7 @@ fn setup(mut commands: Commands) {
                     Text::new("Receiving"),
                     TextFont {
                         font: Default::default(),
-                        font_size: 20.0,
+                        font_size: FontSize::Px(20.0),
                         ..Default::default()
                     },
                     TextColor(Color::srgb(0.9, 0.9, 0.9)),

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -25,4 +25,4 @@ smol-hyper = { version = "0.1.1", default-features = false, features = ["async-i
 thiserror = "1.0.58"
 
 [dev-dependencies]
-bevy = "0.14.0"
+bevy = "0.19.0"

--- a/src/access/as_asset.rs
+++ b/src/access/as_asset.rs
@@ -137,10 +137,16 @@ impl GetHandle for bevy::text::TextFont {
     type Asset = bevy::text::Font;
 
     fn get_asset_id(&self) -> AssetId<Self::Asset> {
-        self.font.id()
+        match &self.font {
+            bevy::text::FontSource::Handle(handle) => handle.id(),
+            _ => panic!("TextFont does not contain a font asset handle"),
+        }
     }
 
     fn get_handle(&self) -> Handle<Self::Asset> {
-        self.font.clone()
+        match &self.font {
+            bevy::text::FontSource::Handle(handle) => handle.clone(),
+            _ => panic!("TextFont does not contain a font asset handle"),
+        }
     }
 }

--- a/src/access/async_asset.rs
+++ b/src/access/async_asset.rs
@@ -52,7 +52,11 @@ impl AssetSet {
             panic!("AssetServer does not exist.")
         }
         self.0.count.fetch_add(1, Ordering::AcqRel);
-        ASSET_SERVER.with(|s| s.load_acquire::<A, _>(path, AssetBarrierGuard(self.0.clone())))
+        ASSET_SERVER.with(|s| {
+            s.load_builder()
+                .with_guard(AssetBarrierGuard(self.0.clone()))
+                .load(path.into())
+        })
     }
 
     /// Wait for all loading to complete.
@@ -135,7 +139,9 @@ impl AsyncWorld {
         if !ASSET_SERVER.is_set() {
             panic!("AssetServer does not exist.")
         }
-        AsyncAsset::Strong(ASSET_SERVER.with(|s| s.load_with_settings::<A, S>(path, f)))
+        AsyncAsset::Strong(
+            ASSET_SERVER.with(|s| s.load_builder().with_settings::<S>(f).load(path.into())),
+        )
     }
 
     /// Add an asset and obtain its handle.

--- a/src/access/async_query.rs
+++ b/src/access/async_query.rs
@@ -1,6 +1,6 @@
 use crate::{executor::with_world_mut, AccessError};
 use bevy::ecs::entity::EntityEquivalent;
-use bevy::ecs::query::{QuerySingleError, ReadOnlyQueryData};
+use bevy::ecs::query::{IterQueryData, QuerySingleError, ReadOnlyQueryData};
 #[allow(unused)]
 use bevy::ecs::system::Query;
 use bevy::ecs::world::CommandQueue;
@@ -105,7 +105,7 @@ impl<T: QueryData, F: QueryFilter> AsyncQuery<T, F> {
     }
 }
 
-impl<T: QueryData + 'static, F: QueryFilter + 'static> AsyncQuery<T, F> {
+impl<T: QueryData + IterQueryData + 'static, F: QueryFilter + 'static> AsyncQuery<T, F> {
     /// Run a function on the iterator.
     pub fn for_each(&self, mut f: impl FnMut(T::Item<'_, '_>)) {
         with_world_mut(move |w| {
@@ -185,7 +185,10 @@ impl<D: QueryData + 'static, F: QueryFilter + 'static> OwnedQueryState<'_, D, F>
             })
     }
 
-    pub fn single_mut(&mut self) -> Result<D::Item<'_, '_>, AccessError> {
+    pub fn single_mut(&mut self) -> Result<D::Item<'_, '_>, AccessError>
+    where
+        D: IterQueryData,
+    {
         self.state
             .as_mut()
             .unwrap()
@@ -235,7 +238,10 @@ impl<D: QueryData + 'static, F: QueryFilter + 'static> OwnedQueryState<'_, D, F>
     pub fn iter_many_mut<E: IntoIterator<Item: EntityEquivalent>>(
         &mut self,
         entities: E,
-    ) -> QueryManyIter<'_, '_, D, F, E::IntoIter> {
+    ) -> QueryManyIter<'_, '_, D, F, E::IntoIter>
+    where
+        D: IterQueryData,
+    {
         self.state
             .as_mut()
             .unwrap()
@@ -246,12 +252,15 @@ impl<D: QueryData + 'static, F: QueryFilter + 'static> OwnedQueryState<'_, D, F>
         self.state.as_mut().unwrap().iter(self.world)
     }
 
-    pub fn iter_mut(&mut self) -> QueryIter<'_, '_, D, F> {
+    pub fn iter_mut(&mut self) -> QueryIter<'_, '_, D, F>
+    where
+        D: IterQueryData,
+    {
         self.state.as_mut().unwrap().iter_mut(self.world)
     }
 }
 
-impl<'s, D: QueryData + 'static, F: QueryFilter + 'static> IntoIterator
+impl<'s, D: QueryData + IterQueryData + 'static, F: QueryFilter + 'static> IntoIterator
     for &'s mut OwnedQueryState<'_, D, F>
 {
     type Item = D::Item<'s, 's>;

--- a/src/access/impls.rs
+++ b/src/access/impls.rs
@@ -15,7 +15,9 @@ use crate::{
 };
 use bevy::asset::{Asset, Assets};
 use bevy::ecs::component::Mutable;
-use bevy::ecs::query::{ReadOnlyQueryData, ReleaseStateQueryData};
+use bevy::ecs::query::{
+    IterQueryData, ReadOnlyQueryData, ReleaseStateQueryData, SingleEntityQueryData,
+};
 use bevy::ecs::relationship::RelationshipTarget;
 use bevy::ecs::{
     component::Component,
@@ -519,7 +521,11 @@ impl_async_access! {
                 name: type_name::<R>(),
             })
         }
+    }
+}
 
+impl_async_access! {
+    impl[R: Resource<Mutability = Mutable>] AsyncResource [R] {
         fn get_mut(this: &Self, world: &mut World) -> AccessResult<&mut R> {
             world.get_resource_mut::<R>()
                 .map(|x| x.into_inner())
@@ -541,13 +547,13 @@ impl<R: 'static> ShouldContinue for AsyncNonSend<R> {
 impl_async_access! {
     impl[R: 'static] AsyncNonSend [R] {
         fn get(this: &Self, world: &World) -> AccessResult<&R> {
-            world.get_non_send_resource::<R>().ok_or(AccessError::ResourceNotFound {
+            world.get_non_send::<R>().ok_or(AccessError::ResourceNotFound {
                 name: type_name::<R>(),
             })
         }
 
         fn get_mut(this: &Self, world: &mut World) -> AccessResult<&mut R> {
-            world.get_non_send_resource_mut::<R>()
+            world.get_non_send_mut::<R>()
                 .map(|x| x.into_inner())
                 .ok_or(AccessError::ResourceNotFound {
                     name: type_name::<R>(),
@@ -588,6 +594,7 @@ impl_async_access! {
                     name: type_name::<Assets<T>>(),
                 })?
                 .get_mut(id)
+                .map(|x| x.into_inner())
                 .ok_or(AccessError::AssetNotFound {
                     name: type_name::<T>(),
                 })
@@ -630,7 +637,7 @@ impl_async_access! {
 impl<D: QueryData, F: QueryFilter> ShouldContinue for AsyncEntityQuery<D, F> {}
 
 impl_async_access! {
-    impl[D: ReadOnlyQueryData + ReleaseStateQueryData + 'static, F: QueryFilter + 'static] AsyncEntityQuery [D, F] {
+    impl[D: ReadOnlyQueryData + ReleaseStateQueryData + SingleEntityQueryData + 'static, F: QueryFilter + 'static] AsyncEntityQuery [D, F] {
         fn get(this: &Self, world: &World) -> AccessResult<D::Item<'_, '_>> {
             let entity = this.id();
             world
@@ -646,7 +653,7 @@ impl_async_access! {
 }
 
 impl_async_access! {
-    impl[D: QueryData + ReleaseStateQueryData + 'static, F: QueryFilter + 'static] AsyncEntityQuery [D, F] {
+    impl[D: QueryData + ReleaseStateQueryData + SingleEntityQueryData + 'static, F: QueryFilter + 'static] AsyncEntityQuery [D, F] {
         fn get_mut(this: &Self, world: &mut World) -> AccessResult<D::Item<'_, '_>> {
             let entity = this.id();
             let mut e = world
@@ -664,7 +671,7 @@ impl_async_access! {
 impl<D: QueryData, F: QueryFilter> ShouldContinue for AsyncQuerySingle<D, F> {}
 
 impl_async_access! {
-    impl[D: QueryData + 'static, F: QueryFilter + 'static] AsyncQuerySingle [D, F] {
+    impl[D: QueryData + IterQueryData + 'static, F: QueryFilter + 'static] AsyncQuerySingle [D, F] {
         fn get_mut(this: &Self, world: &mut World) -> AccessResult<D::Item<'_, '_>> {
             let mut query = OwnedQueryState::<D, F>::new(world);
             query.single_mut()
@@ -712,7 +719,7 @@ impl<D: QueryData + 'static, F: QueryFilter + 'static> AsyncQuery<D, F> {
     }
 }
 
-impl<R: Resource> AsyncResource<R> {
+impl<R: Resource<Mutability = Mutable>> AsyncResource<R> {
     /// Run a function on this resource, panics if not exist.
     #[track_caller]
     pub fn with<A>(&self, f: impl FnOnce(&mut R) -> A) -> A {
@@ -724,6 +731,6 @@ impl<R: 'static> AsyncNonSend<R> {
     /// Run a function on this non-send resource, panics if not exist.
     #[track_caller]
     pub fn with<A>(&self, f: impl FnOnce(&mut R) -> A) -> A {
-        with_world_mut(|world| f(world.non_send_resource_mut::<R>().into_inner()))
+        with_world_mut(|world| f(world.non_send_mut::<R>().into_inner()))
     }
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -41,7 +41,9 @@ impl AsyncWorld {
     /// # );
     /// ```
     pub fn apply_command(&self, command: impl Command) {
-        with_world_mut(|w| command.apply(w))
+        with_world_mut(|w| {
+            command.apply(w);
+        })
     }
 
     /// Apply a [`CommandQueue`].

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -77,8 +77,8 @@ impl AsyncExecutor {
 /// System for running [`AsyncExecutor`].
 pub fn run_async_executor(world: &mut World) {
     let reactors = world.resource::<Reactors>().clone();
-    let queue = world.non_send_resource::<QueryQueue>().clone();
-    let executor = world.non_send_resource::<AsyncExecutor>().clone();
+    let queue = world.non_send::<QueryQueue>().clone();
+    let executor = world.non_send::<AsyncExecutor>().clone();
     let assets = world.get_resource::<AssetServer>().cloned();
 
     let mut f = || {

--- a/src/ext/scene.rs
+++ b/src/ext/scene.rs
@@ -4,7 +4,7 @@ use bevy::ecs::component::Component;
 use bevy::ecs::query::With;
 use bevy::ecs::system::{Commands, Query};
 use bevy::ecs::{bundle::Bundle, entity::Entity};
-use bevy::scene::SceneInstance;
+use bevy::world_serialization::WorldInstance;
 use std::borrow::Borrow;
 
 /// A component that sends a signal and removes itself
@@ -15,7 +15,7 @@ pub struct SceneSignal(async_oneshot::Sender<()>);
 /// Send [`SceneSignal`] once scene is loaded.
 pub fn react_to_scene_load(
     mut commands: Commands,
-    mut query: Query<(Entity, &mut SceneSignal), With<SceneInstance>>,
+    mut query: Query<(Entity, &mut SceneSignal), With<WorldInstance>>,
 ) {
     for (entity, mut signal) in query.iter_mut() {
         let _ = signal.0.send(());

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -7,7 +7,7 @@ use bevy::ecs::{
     component::Component,
     entity::Entity,
     name::Name,
-    query::{QueryFilter, ReadOnlyQueryData, ReleaseStateQueryData},
+    query::{QueryFilter, ReadOnlyQueryData, ReleaseStateQueryData, SingleEntityQueryData},
     resource::Resource,
 };
 use ref_cast::RefCast;
@@ -104,7 +104,7 @@ impl EntityInspectors {
 
     /// Add an inspector function at a priority if a query is successful.
     pub fn push_query<
-        Q: ReadOnlyQueryData + ReleaseStateQueryData + 'static,
+        Q: ReadOnlyQueryData + ReleaseStateQueryData + SingleEntityQueryData + 'static,
         F: QueryFilter + 'static,
     >(
         &mut self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,9 @@ use bevy::app::{App, First, Plugin, PostUpdate, PreUpdate, Update};
 use bevy::ecs::component::Component;
 use bevy::ecs::intern::Interned;
 use bevy::ecs::message::Message;
-use bevy::ecs::query::{QueryFilter, ReadOnlyQueryData, ReleaseStateQueryData};
+use bevy::ecs::query::{
+    QueryFilter, ReadOnlyQueryData, ReleaseStateQueryData, SingleEntityQueryData,
+};
 use bevy::ecs::schedule::IntoScheduleConfigs as _;
 use bevy::ecs::system::Command;
 use bevy::prelude::EntityCommands;
@@ -106,8 +108,8 @@ pub struct CoreAsyncPlugin;
 
 impl Plugin for CoreAsyncPlugin {
     fn build(&self, app: &mut App) {
-        app.init_non_send_resource::<QueryQueue>()
-            .init_non_send_resource::<AsyncExecutor>()
+        app.init_non_send::<QueryQueue>()
+            .init_non_send::<AsyncExecutor>()
             .init_resource::<Reactors>()
             .init_resource::<EntityInspectors>()
             .register_type::<Signals>()
@@ -273,7 +275,7 @@ pub trait AsyncExtension {
     /// Only the first successful formatting function will be called according to their priorities.
     /// A [`Name`](bevy::core::Name) based method is automatically added at priority `0`.
     fn register_inspect_entity_by_query<
-        Q: ReadOnlyQueryData + ReleaseStateQueryData + 'static,
+        Q: ReadOnlyQueryData + ReleaseStateQueryData + SingleEntityQueryData + 'static,
         F: QueryFilter + 'static,
     >(
         &mut self,
@@ -284,7 +286,7 @@ pub trait AsyncExtension {
 
 impl AsyncExtension for World {
     fn spawn_task(&mut self, f: impl Future<Output = AccessResult> + 'static) -> &mut Self {
-        self.non_send_resource::<AsyncExecutor>().spawn(f);
+        self.non_send::<AsyncExecutor>().spawn(f);
         self
     }
 
@@ -301,7 +303,7 @@ impl AsyncExtension for World {
                 })
             }
         };
-        let task = self.non_send_resource::<AsyncExecutor>().spawn_task(fut);
+        let task = self.non_send::<AsyncExecutor>().spawn_task(fut);
         if let Some(mut res) = self.get_resource_mut::<ScopedTasks<S>>() {
             res.tasks.entry(state).or_default().push(task);
         } else {
@@ -323,7 +325,7 @@ impl AsyncExtension for World {
     }
 
     fn register_inspect_entity_by_query<
-        Q: ReadOnlyQueryData + ReleaseStateQueryData + 'static,
+        Q: ReadOnlyQueryData + ReleaseStateQueryData + SingleEntityQueryData + 'static,
         F: QueryFilter + 'static,
     >(
         &mut self,
@@ -343,7 +345,7 @@ impl AsyncExtension for World {
 
 impl AsyncExtension for App {
     fn spawn_task(&mut self, f: impl Future<Output = AccessResult> + 'static) -> &mut Self {
-        self.world().non_send_resource::<AsyncExecutor>().spawn(f);
+        self.world().non_send::<AsyncExecutor>().spawn(f);
         self
     }
 
@@ -371,7 +373,7 @@ impl AsyncExtension for App {
     }
 
     fn register_inspect_entity_by_query<
-        Q: ReadOnlyQueryData + ReleaseStateQueryData + 'static,
+        Q: ReadOnlyQueryData + ReleaseStateQueryData + SingleEntityQueryData + 'static,
         F: QueryFilter + 'static,
     >(
         &mut self,
@@ -536,6 +538,8 @@ impl SpawnFn {
 }
 
 impl Command for SpawnFn {
+    type Out = ();
+
     fn apply(self, world: &mut World) {
         world.spawn_task(self.0());
     }
@@ -560,6 +564,8 @@ impl<S: States> StateScopedSpawnFn<S> {
 }
 
 impl<S: States> Command for StateScopedSpawnFn<S> {
+    type Out = ();
+
     fn apply(self, world: &mut World) {
         let _ = world.spawn_state_scoped(self.state, (self.future)());
     }
@@ -676,8 +682,8 @@ macro_rules! test_spawn {
         app.world_mut().spawn(Str("Ferris"));
         app.insert_resource(Int(4));
         app.insert_resource(Str("Ferris"));
-        app.insert_non_send_resource(Int(4));
-        app.insert_non_send_resource(Str("Ferris"));
+        app.insert_non_send(Int(4));
+        app.insert_non_send(Str("Ferris"));
         app.insert_state(MyState::A);
         app.spawn_task(async move {
             $expr;

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -167,18 +167,18 @@ impl QueryQueue {
 
 /// System that tries to resolve queries sent to the queue.
 pub fn run_watch_queries(world: &mut World) {
-    let query_queue = world.remove_non_send_resource::<QueryQueue>().unwrap();
+    let query_queue = world.remove_non_send::<QueryQueue>().unwrap();
     query_queue
         .repeat_queue
         .borrow_mut()
         .retain_mut(|f| (f.command)(world));
     query_queue.yielded.wake();
-    world.insert_non_send_resource(query_queue);
+    world.insert_non_send(query_queue);
 }
 
 /// Run `fixed_queue` on [`Update`].
 pub fn run_fixed_queue(world: &mut World) {
-    let query_queue = world.remove_non_send_resource::<QueryQueue>().unwrap();
+    let query_queue = world.remove_non_send::<QueryQueue>().unwrap();
     let delta_time = world.resource::<Time>().delta();
     query_queue.fixed_queue.borrow_mut().retain_mut(|x| {
         if x.cancel.cancelled() {
@@ -186,7 +186,7 @@ pub fn run_fixed_queue(world: &mut World) {
         }
         !(x.task)(world, delta_time)
     });
-    world.insert_non_send_resource(query_queue);
+    world.insert_non_send(query_queue);
 }
 
 /// Run `sleep` and `sleep_frames` reactors.


### PR DESCRIPTION
Hello, 

Thank you kindly for bevy_defer. I think it's a really important part of the Bevy toolkit. I updated it to Bevy 0.19, but two of my changes deserve closer scrutiny. They are in commits prefixed with "hack:".

The `GetHandle` implementation for `TextFont` can now panic with valid `font` field values, which doesn't seem right.

This one I was most concerned about because I still think it's wrong. But the thing I thought would fix it still left the `dance` example hanging after it printed "3".
```rust
    fn write_if_changed(&self, item: T) -> u32
    where
        T: PartialEq,
    {
        let mut lock = self.value.write().unwrap();
        // XXX: Original code was this:
        //if lock.as_ref().is_some_and(|x| x == &item) {
        // I thought this would fix it:
        //if lock.as_ref().is_some_and(|x| x != &item) {
        // But this is what actually made the `dance` example work, but
        // I still think it's wrong.
        if !lock.as_ref().is_some_and(|x| x == &item) {
            let result = self.tick.fetch_add(1, Ordering::Relaxed).wrapping_add(1);
            *lock = Some(item);
            self.event.notify(usize::MAX);
            result
        } else {
            self.read_tick()
        }
    }
```

I also bumped the version number and updated the README compatibility table.